### PR TITLE
Basic unit tests, text length limitation, return entire JSON, minor changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 pydeepl
 =======
 
-A python API wrapper for deepl.com translating service.
+A Python API wrapper for the `DeepL <https://www.deepl.com/>`_ translation service.
 
 Installation
 ------------
@@ -16,7 +16,7 @@ Getting Started
 Python Version
 ~~~~~~~~~~~~~~
 
-Pydeepl was written for both python 2 and python 3.
+Pydeepl was written for both Python 2 and Python 3.
 
 Add pydeepl to your application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,7 +61,7 @@ Pydeepl supports these languages:
 | PL     | Polish          |
 +--------+-----------------+
 
-    Note that auto detection only is possible for the source language.
+    Note that auto detection is only possible for the source language.
 
 Disclaimer
 ----------

--- a/pydeepl/__init__.py
+++ b/pydeepl/__init__.py
@@ -1,1 +1,1 @@
-from .pydeepl import translate
+from .pydeepl import translate, TranslationError

--- a/pydeepl/pydeepl.py
+++ b/pydeepl/pydeepl.py
@@ -1,5 +1,4 @@
 import requests
-import json
 
 BASE_URL = 'https://www.deepl.com/jsonrpc'
 
@@ -23,9 +22,11 @@ class TranslationError(Exception):
         super(TranslationError, self).__init__(message)
 
 
-def translate(text, to_lang, from_lang='auto'):
+def translate(text, to_lang, from_lang='auto', json=False):
     if text is None:
         raise TranslationError('Text can\'t be None.')
+    if len(text) > 5000:
+        raise TranslationError('Text too long (limited to 5000 characters).')
     if to_lang not in LANGUAGES.keys():
         raise TranslationError('Language {} not available.'.format(to_lang))
     if from_lang is not None and from_lang not in LANGUAGES.keys():
@@ -52,7 +53,7 @@ def translate(text, to_lang, from_lang='auto'):
         },
     }
 
-    response = json.loads(requests.post(BASE_URL, json=parameters).text)
+    response = requests.post(BASE_URL, json=parameters).json()
 
     if 'result' not in response:
         raise TranslationError('DeepL call resulted in a unknown result.')
@@ -64,4 +65,6 @@ def translate(text, to_lang, from_lang='auto'):
             or translations[0]['beams'][0]['postprocessed_sentence'] is None:
         raise TranslationError('No translations found.')
 
+    if json:
+        return response
     return translations[0]['beams'][0]['postprocessed_sentence']

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,34 @@
+import pydeepl
+import unittest
+
+
+class BasicTests(unittest.TestCase):
+    def test(self):
+        for e in [
+                {
+                    "sentence": "I like turtles.",
+                    "from_language": "EN",
+                    "to_language": "ES",
+                    "result": "Me gustan las tortugas."
+                }]:
+            # Origin language provided
+            translation = pydeepl.translate(e["sentence"], e["to_language"], e["from_language"])
+            self.assertEqual(translation, e["result"])
+            # Using auto-detection
+            translation = pydeepl.translate(e["sentence"], e["to_language"])
+            self.assertEqual(translation, e["result"])
+
+    def test_exceptions(self):
+        sentence = 'I like turtles.'
+        # Language not available
+        with self.assertRaises(pydeepl.TranslationError):
+            pydeepl.translate(sentence, "XX")
+        # Empty text
+        with self.assertRaises(pydeepl.TranslationError):
+            pydeepl.translate(None, "EN")
+        # Text too long
+        with self.assertRaises(pydeepl.TranslationError):
+            pydeepl.translate("a" * 5001, "EN")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add text length limitation.
- Option to return the entire json response.
- Use requests .json() method instead of calling json.loads.
- Other minor changes.