### PR TITLE
Implement request method for text splitting api call

### DIFF
--- a/pydeepl/__init__.py
+++ b/pydeepl/__init__.py
@@ -1,1 +1,1 @@
-from .pydeepl import translate, TranslationError
+from .pydeepl import split_sentences, SplittingError, translate, TranslationError

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 setup(
     name='pydeepl',
     packages=['pydeepl'],
-    version='0.9',
+    version='0.10',
     description='A python API wrapper for DeepL translating service.',
     long_description=readme(),
     author='Emilio Carrión Peñalba, frinkelpi',


### PR DESCRIPTION
Hi, I added an API call for splitting text blocks into sentences using DeepL JSONRPC. This means that even larger text modules can be comfortably translated. What to you think?