### PR TITLE
URL Update

### DIFF
--- a/pydeepl/pydeepl.py
+++ b/pydeepl/pydeepl.py
@@ -1,6 +1,6 @@
 import requests
 
-BASE_URL = 'https://www.deepl.com/jsonrpc'
+BASE_URL = 'https://www2.deepl.com/jsonrpc'
 
 LANGUAGES = {
     'auto': 'Auto',


### PR DESCRIPTION
www.deepl.com/jsonrpc ist outdated. Use www2.deepl.com/jsonrpc instead.